### PR TITLE
[nondex2] with clean config

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     val asmVersion = "9.2"
     plugin("org.ow2.asm:asm:${asmVersion}")
 
+    implementation("edu.illinois:nondex-common:1.1.3-SNAPSHOT")
+    implementation("edu.illinois:nondex-instrumentation:1.1.3-SNAPSHOT")
+
     testImplementation(gradleTestKit())
     testImplementation(localGroovy())
     testImplementation("org.spockframework:spock-core:2.0-groovy-3.0")

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
@@ -3,20 +3,36 @@ package org.gradle.testretry.internal.executer;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
 
+import edu.illinois.nondex.common.Configuration;
+import edu.illinois.nondex.common.Level;
+import edu.illinois.nondex.common.Logger;
+import edu.illinois.nondex.common.Utils;
+
 public class CleanExecution {
+
+    protected Configuration configuration;
+    protected final String executionId;
 
     private final TestExecuter<JvmTestExecutionSpec> delegate;
     protected JvmTestExecutionSpec originalSpec;
     private RetryTestResultProcessor testResultProcessor;
 
-    public CleanExecution(TestExecuter<JvmTestExecutionSpec> delegate, JvmTestExecutionSpec originalSpec,
-            RetryTestResultProcessor testResultProcessor) {
+    protected CleanExecution(TestExecuter<JvmTestExecutionSpec> delegate, JvmTestExecutionSpec originalSpec,
+            RetryTestResultProcessor testResultProcessor, String executionId, String nondexDir) {
         this.delegate = delegate;
         this.originalSpec = originalSpec;
         this.testResultProcessor = testResultProcessor;
+        this.executionId = executionId;
+        this.configuration = new Configuration(executionId, nondexDir);
+    }
+
+    public CleanExecution(TestExecuter<JvmTestExecutionSpec> delegate, JvmTestExecutionSpec originalSpec,
+            RetryTestResultProcessor testResultProcessor, String nondexDir) {
+        this(delegate, originalSpec, testResultProcessor, "clean_" + Utils.getFreshExecutionId(), nondexDir);
     }
 
     public RetryTestResultProcessor run() {
+        Logger.getGlobal().log(Level.CONFIG, this.configuration.toString());
         this.delegate.execute(this.originalSpec, this.testResultProcessor);
         return this.testResultProcessor;
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -69,19 +69,6 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     @Override
     public void execute(JvmTestExecutionSpec spec, TestResultProcessor testResultProcessor) {
-        String outPath = System.getProperty("user.dir")+ File.separator
-                + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR + File.separator
-                + ConfigurationDefaults.INSTRUMENTATION_JAR;
-        try {
-            File fileForJar = Paths.get(System.getProperty("user.dir"), 
-                    ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
-            fileForJar.mkdirs();
-            Main.main(Paths.get(fileForJar.getAbsolutePath(),
-                    ConfigurationDefaults.INSTRUMENTATION_JAR).toString());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
         int maxRetries = extension.getMaxRetries();
         int maxFailures = extension.getMaxFailures();
         boolean failOnPassedAfterRetry = extension.getFailOnPassedAfterRetry();

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -69,9 +69,6 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     @Override
     public void execute(JvmTestExecutionSpec spec, TestResultProcessor testResultProcessor) {
-        String outPath = System.getProperty("user.dir")+ File.separator
-                + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR + File.separator
-                + ConfigurationDefaults.INSTRUMENTATION_JAR;
         try {
             File fileForJar = Paths.get(System.getProperty("user.dir"),
                     ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -28,10 +28,14 @@ import org.gradle.testretry.internal.filter.AnnotationInspectorImpl;
 import org.gradle.testretry.internal.filter.RetryFilter;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy.gradleVersionIsAtLeast;
+
+import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.instr.Main;
 
 public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
 
@@ -65,6 +69,19 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     @Override
     public void execute(JvmTestExecutionSpec spec, TestResultProcessor testResultProcessor) {
+        String outPath = System.getProperty("user.dir")+ File.separator
+                + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR + File.separator
+                + ConfigurationDefaults.INSTRUMENTATION_JAR;
+        try {
+            File fileForJar = Paths.get(System.getProperty("user.dir"), 
+                    ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
+            fileForJar.mkdirs();
+            Main.main(Paths.get(fileForJar.getAbsolutePath(),
+                    ConfigurationDefaults.INSTRUMENTATION_JAR).toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         int maxRetries = extension.getMaxRetries();
         int maxFailures = extension.getMaxFailures();
         boolean failOnPassedAfterRetry = extension.getFailOnPassedAfterRetry();

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -69,6 +69,19 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     @Override
     public void execute(JvmTestExecutionSpec spec, TestResultProcessor testResultProcessor) {
+        String outPath = System.getProperty("user.dir")+ File.separator
+                + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR + File.separator
+                + ConfigurationDefaults.INSTRUMENTATION_JAR;
+        try {
+            File fileForJar = Paths.get(System.getProperty("user.dir"),
+                    ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
+            fileForJar.mkdirs();
+            Main.main(Paths.get(fileForJar.getAbsolutePath(),
+                    ConfigurationDefaults.INSTRUMENTATION_JAR).toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         int maxRetries = extension.getMaxRetries();
         int maxFailures = extension.getMaxFailures();
         boolean failOnPassedAfterRetry = extension.getFailOnPassedAfterRetry();
@@ -99,12 +112,14 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
         int retryCount = 0;
         JvmTestExecutionSpec testExecutionSpec = spec;
 
-        CleanExecution cleanExec = new CleanExecution(this.delegate, testExecutionSpec, retryTestResultProcessor);
+        CleanExecution cleanExec = new CleanExecution(this.delegate, testExecutionSpec, retryTestResultProcessor,
+                System.getProperty("user.dir")+ File.separator + ConfigurationDefaults.DEFAULT_NONDEX_DIR);
         retryTestResultProcessor = cleanExec.run();
 
         while (true) {
             retryTestResultProcessor.reset(++retryCount == maxRetries);
-            CleanExecution execution = new CleanExecution(this.delegate, testExecutionSpec, retryTestResultProcessor);
+            CleanExecution execution = new CleanExecution(this.delegate, testExecutionSpec, retryTestResultProcessor,
+                    System.getProperty("user.dir")+ File.separator + ConfigurationDefaults.DEFAULT_NONDEX_DIR);
             retryTestResultProcessor = execution.run();
             RoundResult result = retryTestResultProcessor.getResult();
             lastResult = result;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
1. add nondex dependencies in the build script
2. create instrumentation jar
3. add configuration to `CleanExecution` class; the configuration constructor creates a directory whose name is the executionId for each test run
