### PR TITLE
[nondex3] shuffle with different seeds

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/NonDexExecution.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/NonDexExecution.java
@@ -1,0 +1,99 @@
+package org.gradle.testretry.internal.executer;
+
+import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
+import org.gradle.api.internal.tasks.testing.TestExecuter;
+import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations;
+import org.gradle.process.JavaForkOptions;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.nio.file.Paths;
+
+import edu.illinois.nondex.common.Configuration;
+import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Utils;
+import edu.illinois.nondex.common.Logger;
+import java.util.regex.Pattern;
+
+import static org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy.gradleVersionIsAtLeast;
+
+public class NonDexExecution extends CleanExecution {
+    private NonDexExecution(TestExecuter<JvmTestExecutionSpec> delegate, JvmTestExecutionSpec spec, 
+            RetryTestResultProcessor testResultProcessor, String nondexDir) {
+        super(delegate, spec, testResultProcessor, Utils.getFreshExecutionId(), nondexDir);
+    }
+
+    public NonDexExecution(int seed, TestExecuter<JvmTestExecutionSpec> delegate, JvmTestExecutionSpec originalSpec, 
+            RetryTestResultProcessor testResultProcessor, String nondexDir, String nondexJarDir) {
+        this(delegate, originalSpec, testResultProcessor, nondexDir);
+        this.configuration = new Configuration(ConfigurationDefaults.DEFAULT_MODE, seed, Pattern.compile(ConfigurationDefaults.DEFAULT_FILTER), 
+                ConfigurationDefaults.DEFAULT_START, ConfigurationDefaults.DEFAULT_END, nondexDir, nondexJarDir, null,
+                this.executionId, Logger.getGlobal().getLoggingLevel());
+        this.originalSpec = this.createRetryJvmExecutionSpec();
+    }
+
+    private JvmTestExecutionSpec createRetryJvmExecutionSpec() {
+        JvmTestExecutionSpec spec = this.originalSpec;
+        JavaForkOptions option = spec.getJavaForkOptions();
+        List<String> arg = this.setupArgline();
+        option.setJvmArgs(arg);
+        if (gradleVersionIsAtLeast("6.4")) {
+            // This constructor is in Gradle 6.4+
+            return new JvmTestExecutionSpec(
+                spec.getTestFramework(),
+                spec.getClasspath(),
+                spec.getModulePath(),
+                spec.getCandidateClassFiles(),
+                spec.isScanForTestClasses(),
+                spec.getTestClassesDirs(),
+                spec.getPath(),
+                spec.getIdentityPath(),
+                spec.getForkEvery(),
+                option,
+                spec.getMaxParallelForks(),
+                spec.getPreviousFailedTestClasses()
+            );
+        } else {
+            // This constructor is in Gradle 4.7+
+            return new JvmTestExecutionSpec(
+                spec.getTestFramework(),
+                spec.getClasspath(),
+                spec.getCandidateClassFiles(),
+                spec.isScanForTestClasses(),
+                spec.getTestClassesDirs(),
+                spec.getPath(),
+                spec.getIdentityPath(),
+                spec.getForkEvery(),
+                option,
+                spec.getMaxParallelForks(),
+                spec.getPreviousFailedTestClasses()
+            );
+        }
+    }
+
+    private List<String> setupArgline() {
+        String pathToNondex = getPathToNondexJar();
+        List<String> arg = new ArrayList();
+        if (!Utils.checkJDKBefore8()) {
+            arg.add("--patch-module=java.base=" + pathToNondex);
+            arg.add("--add-exports=java.base/edu.illinois.nondex.common=ALL-UNNAMED");
+            arg.add("--add-exports=java.base/edu.illinois.nondex.shuffling=ALL-UNNAMED");
+        } else {
+            arg.add("-Xbootclasspath/p:" + pathToNondex);
+        }
+        arg.add("-D" + ConfigurationDefaults.PROPERTY_EXECUTION_ID + "=" + this.configuration.executionId);
+        arg.add("-D" + ConfigurationDefaults.PROPERTY_SEED + "=" + this.configuration.seed);
+        return arg;
+    }
+
+    private String getPathToNondexJar() {
+        DefaultMavenFileLocations loc = new DefaultMavenFileLocations();
+        File mvnLoc = loc.getUserMavenDir();
+        String result = Paths.get(this.configuration.nondexJarDir, ConfigurationDefaults.INSTRUMENTATION_JAR) + File.pathSeparator
+                + Paths.get(mvnLoc.toString(),
+                "repository", "edu", "illinois", "nondex-common", ConfigurationDefaults.VERSION,
+                "nondex-common-" + ConfigurationDefaults.VERSION + ".jar");
+        return result;
+    }
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import static org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy.gradleVersionIsAtLeast;
 
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Utils;
 import edu.illinois.nondex.instr.Main;
 
 public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
@@ -69,9 +70,6 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     @Override
     public void execute(JvmTestExecutionSpec spec, TestResultProcessor testResultProcessor) {
-        String outPath = System.getProperty("user.dir")+ File.separator
-                + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR + File.separator
-                + ConfigurationDefaults.INSTRUMENTATION_JAR;
         try {
             File fileForJar = Paths.get(System.getProperty("user.dir"),
                     ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
@@ -118,8 +116,10 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
         while (true) {
             retryTestResultProcessor.reset(++retryCount == maxRetries);
-            CleanExecution execution = new CleanExecution(this.delegate, testExecutionSpec, retryTestResultProcessor,
-                    System.getProperty("user.dir")+ File.separator + ConfigurationDefaults.DEFAULT_NONDEX_DIR);
+            NonDexExecution execution = new NonDexExecution(this.computeIthSeed(retryCount - 1),
+                    this.delegate, testExecutionSpec, retryTestResultProcessor,
+                    System.getProperty("user.dir")+ File.separator + ConfigurationDefaults.DEFAULT_NONDEX_DIR,
+                    System.getProperty("user.dir")+ File.separator + ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR);
             retryTestResultProcessor = execution.run();
             RoundResult result = retryTestResultProcessor.getResult();
             lastResult = result;
@@ -185,5 +185,9 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
     @Override
     public void stopNow() {
         delegate.stopNow();
+    }
+
+    private int computeIthSeed(int ithSeed) {
+        return Utils.computeIthSeed(ithSeed, false, ConfigurationDefaults.DEFAULT_SEED);
     }
 }


### PR DESCRIPTION
1. create `NonDexExecution` class, which can run tests with nondex shuffling'
2. it used different seeds for nondex shuffling test executions

Note: The method `JvmTestExecutionSpec createRetryJvmExecutionSpec()` is a modified version of the method of [RetryTestExecuter.java](https://github.com/MarcyGO/test-retry-gradle-plugin/compare/nondex2_withCleanConfig...MarcyGO:test-retry-gradle-plugin:nondex3_withNonDexShuffle?expand=1#diff-97cf1b9e6ea5e278f03e505d5c16a25b8655a15868b8ea8d04ba4cdd9f954438)