### PR TITLE
[nondex6] write failures

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
@@ -33,6 +33,10 @@ public class CleanExecution {
         this(delegate, originalSpec, testResultProcessor, "clean_" + Utils.getFreshExecutionId(), nondexDir);
     }
 
+    public Configuration getConfiguration() {
+        return this.configuration;
+    }
+
     public RetryTestResultProcessor run() {
         Logger.getGlobal().log(Level.CONFIG, this.configuration.toString());
         this.delegate.execute(this.originalSpec, this.testResultProcessor);
@@ -40,7 +44,7 @@ public class CleanExecution {
         return this.testResultProcessor;
     }
 
-    public void setFailures() {
+    private void setFailures() {
         Set<String> failingTests = this.testResultProcessor.getFailingTests();
         this.configuration.setFailures(failingTests);
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/CleanExecution.java
@@ -3,6 +3,8 @@ package org.gradle.testretry.internal.executer;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
 
+import java.util.Set;
+
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
@@ -34,6 +36,12 @@ public class CleanExecution {
     public RetryTestResultProcessor run() {
         Logger.getGlobal().log(Level.CONFIG, this.configuration.toString());
         this.delegate.execute(this.originalSpec, this.testResultProcessor);
+        this.setFailures();
         return this.testResultProcessor;
+    }
+
+    public void setFailures() {
+        Set<String> failingTests = this.testResultProcessor.getFailingTests();
+        this.configuration.setFailures(failingTests);
     }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -27,7 +27,9 @@ import org.gradle.testretry.internal.testsreader.TestsReader;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED;
 
@@ -47,6 +49,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
 
     private TestNames currentRoundFailedTests = new TestNames();
     private TestNames previousRoundFailedTests = new TestNames();
+    private Set<String> failingTests = new LinkedHashSet<>();
 
     private Object rootTestDescriptorId;
 
@@ -160,6 +163,8 @@ final class RetryTestResultProcessor implements TestResultProcessor {
             String className = descriptor.getClassName();
             if (className != null) {
                 if (filter.canRetry(className)) {
+                    String name = descriptor.getName();
+                    failingTests.add(className + "#" + name);
                     currentRoundFailedTests.add(className, descriptor.getName());
                 } else {
                     hasRetryFilteredFailures = true;
@@ -189,6 +194,11 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         this.previousRoundFailedTests = currentRoundFailedTests;
         this.currentRoundFailedTests = new TestNames();
         this.activeDescriptorsById.clear();
+        this.failingTests = new LinkedHashSet<>();
+    }
+
+    public Set<String> getFailingTests() {
+        return this.failingTests;
     }
 
 }


### PR DESCRIPTION
1. Write the names of the failing tests to the `failures` text file in the execution directory.
2. For NonDex executions, filter the tests that always fail.